### PR TITLE
refactor: remove shuttle-persist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,8 +690,6 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "serde_json",
- "serde_path_to_error",
  "sync_wrapper",
  "tower",
  "tower-layer",
@@ -753,15 +751,6 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -1544,12 +1533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
-
-[[package]]
 name = "flagset"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,10 +1769,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1980,12 +1961,6 @@ name = "http-range"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "httparse"
@@ -2249,21 +2224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
-dependencies = [
- "base64 0.21.7",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
 ]
 
 [[package]]
@@ -2756,20 +2716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-appender-tracing"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c4bd073648dae8ac45cfc81588d74b3dc5f334119ac08567ddcbfe16f2d809"
-dependencies = [
- "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "opentelemetry-http"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,46 +2724,6 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 0.2.12",
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
- "opentelemetry",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
- "prost 0.11.9",
- "thiserror",
- "tokio",
- "tonic 0.9.2",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
-dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
- "prost 0.11.9",
- "tonic 0.9.2",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
-dependencies = [
  "opentelemetry",
 ]
 
@@ -2838,10 +2744,7 @@ dependencies = [
  "ordered-float",
  "percent-encoding",
  "rand",
- "serde_json",
  "thiserror",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -2933,16 +2836,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
-dependencies = [
- "base64 0.22.1",
- "serde",
 ]
 
 [[package]]
@@ -3212,35 +3105,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "prost-derive",
 ]
 
 [[package]]
@@ -3262,7 +3132,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.6",
+ "prost",
 ]
 
 [[package]]
@@ -3488,6 +3358,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a735987236a8e238bf0296c7e351b999c188ccc11477f311b82b55c93984216"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 0.2.12",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3510,6 +3395,28 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -3546,12 +3453,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -3729,23 +3630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustrict"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe3300a40b60e76a856237ad1fe2210da1f40686705a2211688bb5742109a63"
-dependencies = [
- "arrayvec",
- "bitflags 1.3.2",
- "doc-comment",
- "finl_unicode",
- "itertools 0.10.5",
- "lazy_static",
- "rustc-hash",
- "strsim",
- "unicode-normalization",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3911,16 +3795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
-dependencies = [
- "itoa",
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,7 +3853,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tracing",
  "typemap_rev",
  "url",
@@ -4041,9 +3915,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shuttle-actix-web"
-version = "0.37.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0c350ae943bbe99dc48c7a000374574bc3996cec80d32d3948a919118c1936"
+checksum = "0a2f65afc7b24105b7f8aaecf64bac8e62b161cf2ab949b628bd2ba6e5293ef7"
 dependencies = [
  "actix-web",
  "num_cpus",
@@ -4051,10 +3925,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "shuttle-codegen"
-version = "0.37.0"
+name = "shuttle-api-client"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0b7a98b90227032415702ebd7aa920bfffac52704ede68705ab508d7b477da"
+checksum = "166fbe3022a11ff3f9f771b673f9e39578dec9274a406ff278ed9ee620272e0a"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "headers",
+ "http 0.2.12",
+ "percent-encoding",
+ "reqwest",
+ "reqwest-middleware",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "shuttle-common",
+ "tokio",
+ "tokio-tungstenite 0.20.1",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "shuttle-codegen"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e60a2db8b8548a2a725316ae5d7a04b4dad680a4746372d1b7172f2065f9c345"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -4064,106 +3961,78 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common"
-version = "0.37.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735deac187695b33410cd8cc18ef409db54bcfb27698500eb4624d30f45d7431"
+checksum = "89c694264eba4a286c85f9cc27f0059232fb4863cb668a11286e6b93e879a4d5"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
- "bytes",
  "chrono",
  "comfy-table",
  "crossterm 0.27.0",
- "headers",
  "http 0.2.12",
- "http-body",
- "hyper",
- "jsonwebtoken",
  "opentelemetry",
- "opentelemetry-appender-tracing",
  "opentelemetry-http",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
  "pin-project",
  "reqwest",
- "rustrict",
  "semver 1.0.23",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.26.3",
  "thiserror",
- "tokio",
- "tonic 0.10.2",
  "tower",
- "tower-http",
  "tracing",
- "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "ttl_cache",
+ "typeshare",
  "url",
  "uuid",
  "zeroize",
 ]
 
 [[package]]
-name = "shuttle-persist"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db171667128e007b9dc3411845472ee33d6a90f4136d535051fb958d8ceb253"
-dependencies = [
- "async-trait",
- "bincode",
- "serde",
- "shuttle-service",
- "thiserror",
-]
-
-[[package]]
 name = "shuttle-proto"
-version = "0.37.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11950d438e79df346f0fa7f4ef6265310fade58eeb8122d054ed41f8e8c025ff"
+checksum = "51d322a55314553aad71cd506451b817bec1d2ef5459d939f5642b472870c1e9"
 dependencies = [
  "futures-core",
- "prost 0.12.6",
+ "prost",
  "prost-types",
  "shuttle-common",
- "tonic 0.10.2",
+ "tonic",
 ]
 
 [[package]]
 name = "shuttle-runtime"
-version = "0.37.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e548acb39c387c657c059729a1a8b0e90176ef675b5c989e71b14711ee0dde"
+checksum = "20628ddf00446da52c448ef39b987321227195f6393dc6a5066a12fc22491bd3"
 dependencies = [
  "anyhow",
  "async-trait",
- "chrono",
- "colored",
- "prost-types",
+ "hyper",
  "serde",
  "serde_json",
+ "shuttle-api-client",
  "shuttle-codegen",
  "shuttle-common",
  "shuttle-proto",
  "shuttle-service",
  "strfmt",
- "thiserror",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
- "tower",
+ "tokio-util",
+ "tonic",
+ "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "shuttle-serenity"
-version = "0.37.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f744337f933bd7e2dd8e4a2477f7581c92cdb71a362a2d59fda3c1d7cfb8436f"
+checksum = "f899a80629f3c3d007f0bb8df4ec064b7c9e5758e04e7fe9114929f9c7ef5909"
 dependencies = [
  "serenity",
  "shuttle-runtime",
@@ -4171,15 +4040,14 @@ dependencies = [
 
 [[package]]
 name = "shuttle-service"
-version = "0.37.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a13d269e942132d7936fa538f2e68af267f938a507c91b5e40a5b1b6881c04"
+checksum = "57770033649fa028aa9cc76702c66eb6c93b47a103f5ad15e2739c6404689bba"
 dependencies = [
  "anyhow",
  "async-trait",
  "serde",
  "shuttle-common",
- "shuttle-proto",
  "strfmt",
  "thiserror",
 ]
@@ -4212,18 +4080,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
 ]
 
 [[package]]
@@ -4343,15 +4199,6 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
@@ -4370,19 +4217,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -4475,6 +4309,15 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
+]
 
 [[package]]
 name = "tcp-stream"
@@ -4711,6 +4554,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tungstenite 0.20.1",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
@@ -4721,7 +4579,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
- "tungstenite",
+ "tungstenite 0.21.0",
  "webpki-roots 0.26.6",
 ]
 
@@ -4737,34 +4595,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4785,7 +4615,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.6",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
@@ -4809,25 +4639,6 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.6.0",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body",
- "http-range-header",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4967,7 +4778,6 @@ dependencies = [
  "serde_with",
  "serenity",
  "shuttle-actix-web",
- "shuttle-persist",
  "shuttle-runtime",
  "tokio",
  "trackscape-discord-shared",
@@ -4990,7 +4800,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
- "shuttle-persist",
  "shuttle-runtime",
  "shuttle-serenity",
  "tokio",
@@ -5114,12 +4923,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "ttl_cache"
-version = "0.5.1"
+name = "tungstenite"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4189890526f0168710b6ee65ceaedf1460c48a14318ceec933cb26baa492096a"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "linked-hash-map",
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand",
+ "rustls 0.21.12",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
 ]
 
 [[package]]
@@ -5165,6 +4985,28 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "typeshare"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f17399b76c2e743d58eac0635d7686e9c00f48cd4776f00695d9882a7d3187"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "typeshare-annotation",
+]
+
+[[package]]
+name = "typeshare-annotation"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
+dependencies = [
+ "quote",
+ "syn 2.0.79",
+]
 
 [[package]]
 name = "unicase"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 ![Clan Chat Broadcast](images/clan_chat_broadcast.png)
 ***
 ## Commands
-By default, only Discord users with Manage Server permissions can use the majorty of the commands. This can be changed via Integrations. 
+By default, only Discord users with Manage Server permissions can use the majorty of the commands. This can be changed via Integrations.
 
-> `/info` - Get information about the bot 
+> `/info` - Get information about the bot
 
 > `/set_broadcast_channel channel: {channel}` - Sets the to receive emded Broadcast messages
 
@@ -29,10 +29,10 @@ By default, only Discord users with Manage Server permissions can use the majort
 > `/get_verification_code` - Get the verification code to link your RuneLite TrackScape Connector plugin to the bot
 
 
-***  
+***
 ## Broadcast Types
 
-### Diary Completed 
+### Diary Completed
 ![Diary Completed Broadcast](images/diary_completed_broadcast.png)
 
 ### Item Drop
@@ -64,7 +64,7 @@ Coming soon! Everything needed is in the [.env.save](.env.save) and [production-
     * `DISCORD_TOKEN` This is the discord token created from setting up a discord bot
     * `MANAGEMENT_API_KEY` can be set to w/e. It is used to password protect some endpoints of the API for communication between the bot and the api
     * `DEV_GUILD_ID` is the id of your discord server that is hosting your TrackScape discord bot
-  * The bot and api are ran via [shuttle](https://github.com/shuttle-hq/shuttle). But uses an older version. So may find you need to install it via `cargo binstall cargo-shuttle -y --version 0.37.0`
+  * The bot and api are ran via [shuttle](https://github.com/shuttle-hq/shuttle) via `cargo-shuttle v0.48.1`. If you are using an earlier version, it is recommended to upgrade.
 
 ## Running the Discord bot and API
 1. Make sure docker desktop is running and run `docker compose up -d` in the root of the project. Or make sure your monogodb and redis services are running
@@ -93,7 +93,7 @@ CC will not be able to be sent to Discord and parsed. This is done by the RuneLi
 * [x] Collection Log Leaderboards -  See where you log stands with the rest of the clan
 * [x] Bossing PB Leaderboards - See where you stand with the rest of the clan for fastest kills
 * Simple Team Bingo - to be determined. May not happen
-  - [ ] Bingo tiles by certain drops 
+  - [ ] Bingo tiles by certain drops
     - [ ] Bingo tiles by sets. Barrows, Godsword, etc
   - [ ] Bingo tiles by certain bosses
   - [ ] Bingo tiles by certain xp gain

--- a/dockerfiles/Shuttle.Dockerfile
+++ b/dockerfiles/Shuttle.Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY . /app
 COPY --from=frontend /frontend-app/dist /app/trackscape-discord-api/ui
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-RUN cargo binstall cargo-shuttle -y --version 0.37.0
+RUN cargo binstall cargo-shuttle -y --version 0.48.1
 RUN cargo fetch
 # compile app
 RUN cargo build --release

--- a/trackscape-discord-api/Cargo.toml
+++ b/trackscape-discord-api/Cargo.toml
@@ -13,9 +13,8 @@ mongodb = "2.4.0"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-actix-web = "0.37.0"
-shuttle-runtime = "0.37.0"
-shuttle-persist = "0.37.0"
+shuttle-actix-web = "0.48.1"
+shuttle-runtime = "0.48.1"
 serenity = { version = "0.12.0", default-features = false, features = [
     "http",
     "rustls_backend",

--- a/trackscape-discord-api/Cargo.toml
+++ b/trackscape-discord-api/Cargo.toml
@@ -13,8 +13,8 @@ mongodb = "2.4.0"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-shuttle-actix-web = "0.48.1"
-shuttle-runtime = "0.48.1"
+shuttle-actix-web = "0.48.0"
+shuttle-runtime = "0.48.0"
 serenity = { version = "0.12.0", default-features = false, features = [
     "http",
     "rustls_backend",

--- a/trackscape-discord-bot/Cargo.toml
+++ b/trackscape-discord-bot/Cargo.toml
@@ -10,9 +10,8 @@ anyhow = "1.0.66"
 dotenv = "0.15.0"
 mongodb = "2.4.0"
 xxhash-rust = { version = "0.8.6", features = ["xxh3", "const_xxh3"] }
-shuttle-serenity = "0.37.0"
-shuttle-runtime = "0.37.0"
-shuttle-persist = "0.37.0"
+shuttle-serenity = "0.48.1"
+shuttle-runtime = "0.48.1"
 serenity = { version = "0.12.0", default-features = false, features = [
     "client",
     "gateway",

--- a/trackscape-discord-bot/Cargo.toml
+++ b/trackscape-discord-bot/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0.66"
 dotenv = "0.15.0"
 mongodb = "2.4.0"
 xxhash-rust = { version = "0.8.6", features = ["xxh3", "const_xxh3"] }
-shuttle-serenity = "0.48.1"
-shuttle-runtime = "0.48.1"
+shuttle-serenity = "0.48.0"
+shuttle-runtime = "0.48.0"
 serenity = { version = "0.12.0", default-features = false, features = [
     "client",
     "gateway",

--- a/trackscape-discord-shared/src/jobs/job_helpers.rs
+++ b/trackscape-discord-shared/src/jobs/job_helpers.rs
@@ -1,6 +1,9 @@
 use crate::database::{BotMongoDb, MongoDb};
 use redis::{Connection, RedisResult};
+use serde::Serialize;
 use std::env;
+
+use redis::Commands;
 
 pub async fn get_mongodb() -> BotMongoDb {
     let mongodb_url = env::var("MONGO_DB_URL").expect("MONGO_DB_URL not set!");
@@ -12,4 +15,16 @@ pub fn get_redis_client() -> RedisResult<Connection> {
     redis::Client::open(redis_url)
         .expect("Could not connect to redis")
         .get_connection()
+}
+
+pub async fn write_to_cache<T: Serialize>(
+    redis_connection: &mut Connection,
+    redis_key: String,
+    data: T,
+) {
+    let _: RedisResult<String> = redis_connection.set_ex(
+        redis_key.clone(),
+        serde_json::to_string(&data).unwrap(),
+        3600,
+    );
 }

--- a/trackscape-discord-shared/src/jobs/mod.rs
+++ b/trackscape-discord-shared/src/jobs/mod.rs
@@ -6,10 +6,11 @@ use celery::Celery;
 use std::sync::Arc;
 
 pub mod add_job;
-mod job_helpers;
+pub mod job_helpers;
 pub mod name_change_job;
 pub mod new_pb_job;
 pub mod parse_rl_chat_command;
+pub mod redis_helpers;
 pub mod remove_clanmate_job;
 mod runelite_commands;
 pub mod update_create_clanmate_job;

--- a/trackscape-discord-shared/src/jobs/redis_helpers.rs
+++ b/trackscape-discord-shared/src/jobs/redis_helpers.rs
@@ -1,0 +1,40 @@
+use redis::{Connection, RedisResult};
+use serde::{Deserialize, Serialize};
+
+use redis::Commands;
+
+pub async fn write_to_cache<T: Serialize>(
+    redis_connection: &mut Connection,
+    redis_key: String,
+    data: T,
+) {
+    let _: RedisResult<String> = redis_connection.set_ex(
+        redis_key.clone(),
+        serde_json::to_string(&data).unwrap(),
+        3600,
+    );
+}
+
+pub async fn write_to_cache_with_seconds<T: Serialize>(
+    redis_connection: &mut Connection,
+    redis_key: &str,
+    data: T,
+    seconds: usize,
+) {
+    let _: RedisResult<String> =
+        redis_connection.set_ex(redis_key, serde_json::to_string(&data).unwrap(), seconds);
+}
+
+pub async fn fetch_redis_json_object<T: for<'a> Deserialize<'a>>(
+    redis_connection: &mut Connection,
+    redis_key: &str,
+) -> T {
+    let val = redis::cmd("GET")
+        .arg(redis_key)
+        .query::<String>(redis_connection)
+        .unwrap();
+
+    let val: T = serde_json::from_str(&val).unwrap();
+
+    val
+}

--- a/trackscape-discord-shared/src/jobs/update_create_clanmate_job.rs
+++ b/trackscape-discord-shared/src/jobs/update_create_clanmate_job.rs
@@ -1,8 +1,8 @@
 use crate::database::clan_mates::{ClanMateModel, ClanMates};
-use crate::jobs::job_helpers::{get_mongodb, get_redis_client};
+use crate::jobs::job_helpers::{get_mongodb, get_redis_client, write_to_cache};
 use crate::wom::{get_latest_name_change, get_wom_client};
 use celery::prelude::*;
-use redis::{Commands, Connection, RedisResult};
+use redis::{Commands, RedisResult};
 
 ///
 /// Adds clan mates to the guild if they're not there already, and updates their rank if it's changed.
@@ -163,16 +163,4 @@ pub async fn update_create_clanmate(
 
     println!("update create clan mate job finished");
     Ok(4)
-}
-
-async fn write_to_cache(
-    redis_connection: &mut Connection,
-    redis_key: String,
-    updated_player: ClanMateModel,
-) {
-    let _: RedisResult<String> = redis_connection.set_ex(
-        redis_key.clone(),
-        serde_json::to_string(&updated_player).unwrap(),
-        3600,
-    );
 }


### PR DESCRIPTION
Fixes #41 

As a side note: I moved a couple methods to a file called `redis_helpers.rs` to ensure there were no API breakages. There is also an API change that makes `job_helpers` a public module. We might want to reconfig this if it's intended only for private use.