### PR TITLE
Serenity update and send_message change

### DIFF
--- a/trackscape-discord-api/Cargo.toml
+++ b/trackscape-discord-api/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shuttle-actix-web = "0.48.0"
 shuttle-runtime = "0.48.0"
-serenity = { version = "0.12.0", default-features = false, features = [
+serenity = { version = "0.12.2", default-features = false, features = [
     "http",
     "rustls_backend",
     "model",

--- a/trackscape-discord-shared/src/ge_api.rs
+++ b/trackscape-discord-shared/src/ge_api.rs
@@ -1,6 +1,11 @@
 pub mod ge_api {
+    use redis::Connection;
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
+
+    use crate::redis_helpers::{fetch_redis_json_object, write_to_cache_with_seconds};
+
+    const CACHE_KEY: &str = "ge_mapping";
 
     static APP_USER_AGENT: &str = concat!(
         env!("CARGO_PKG_NAME"),
@@ -11,18 +16,36 @@ pub mod ge_api {
     );
     const BASE_URL: &str = "https://prices.runescape.wiki/api/v1/";
 
-    pub async fn get_item_mapping() -> Result<GeItemMapping, reqwest::Error> {
-        let client = reqwest::Client::builder()
-            .user_agent(APP_USER_AGENT)
-            .build()?;
-        let resp = client
-            .get(format!("{}{}", BASE_URL, "osrs/mapping").as_str())
-            .send()
-            .await?
-            .json::<GeItemMapping>()
-            .await?;
+    pub async fn get_item_mapping(
+        redis_connection: &mut Connection,
+    ) -> Result<GeItemMapping, anyhow::Error> {
+        let cached_result =
+            fetch_redis_json_object::<GeItemMapping>(redis_connection, CACHE_KEY).await;
 
-        Ok(resp)
+        match cached_result {
+            Ok(ge_mapping) => {
+                return Ok(ge_mapping);
+            }
+            Err(_) => {
+                let client = reqwest::Client::builder()
+                    .user_agent(APP_USER_AGENT)
+                    .build()?;
+                let ge_mapping = client
+                    .get(format!("{}{}", BASE_URL, "osrs/mapping").as_str())
+                    .send()
+                    .await?
+                    .json::<GeItemMapping>()
+                    .await?;
+                write_to_cache_with_seconds(
+                    redis_connection,
+                    CACHE_KEY,
+                    ge_mapping.clone(),
+                    604800,
+                )
+                .await;
+                Ok(ge_mapping)
+            }
+        }
     }
 
     pub async fn get_item_value_by_id(id: i64) -> Result<GeItemPrice, reqwest::Error> {

--- a/trackscape-discord-shared/src/jobs/mod.rs
+++ b/trackscape-discord-shared/src/jobs/mod.rs
@@ -10,7 +10,6 @@ pub mod job_helpers;
 pub mod name_change_job;
 pub mod new_pb_job;
 pub mod parse_rl_chat_command;
-pub mod redis_helpers;
 pub mod remove_clanmate_job;
 mod runelite_commands;
 pub mod update_create_clanmate_job;

--- a/trackscape-discord-shared/src/lib.rs
+++ b/trackscape-discord-shared/src/lib.rs
@@ -7,5 +7,6 @@ pub mod helpers;
 pub mod jobs;
 pub mod osrs_broadcast_extractor;
 pub mod osrs_broadcast_handler;
+pub mod redis_helpers;
 pub mod wiki_api;
 pub mod wom;

--- a/trackscape-discord-shared/src/osrs_broadcast_handler.rs
+++ b/trackscape-discord-shared/src/osrs_broadcast_handler.rs
@@ -55,8 +55,8 @@ impl<T: DropLogs, CL: ClanMateCollectionLogTotals, CM: ClanMates, J: JobQueue>
 {
     pub fn new(
         clan_message: ClanMessage,
-        item_mapping_from_state: Result<GeItemMapping, ()>,
-        quests_from_state: Result<Vec<WikiQuest>, ()>,
+        item_mapping_from_state: Result<GeItemMapping, anyhow::Error>,
+        quests_from_state: Result<Vec<WikiQuest>, anyhow::Error>,
         register_guild: RegisteredGuildModel,
         leagues_message: bool,
         drop_log_db: T,


### PR DESCRIPTION
* Updated Serenity to 0.12.2
* Slight refactor to redis cacheing of Ge and Quest data to make sure to refetch when expired
* Moved from `http.send_message` to ChannelId.send_mesage` to hopefully resolve some issues
* Also added logging if `send_message` fails for further trouble shooting