### PR TITLE
Now sends messages in batches

### DIFF
--- a/trackscape-discord-api/src/controllers/bot_info_controller.rs
+++ b/trackscape-discord-api/src/controllers/bot_info_controller.rs
@@ -3,7 +3,7 @@ use actix_web::web::Data;
 use actix_web::{get, post, web, Error, HttpRequest, HttpResponse, Scope};
 use bot_info_dto::DiscordServerCount;
 use dto::bot_info_dto;
-
+use redis::{Commands, RedisResult};
 use serde::{Deserialize, Serialize};
 
 use std::sync::atomic::AtomicI64;
@@ -15,18 +15,37 @@ use web::Json;
 struct BotInfo {
     server_count: i64,
     connected_users: i64,
+    total_chat_messages_for_today: Option<i64>,
 }
 
 #[get("/landing-page-info")]
 async fn get_landing_page_info(
     connected_websockets: Data<Mutex<usize>>,
     connected_discord_servers: Data<AtomicI64>,
+    redis_client: Data<redis::Client>,
 ) -> Result<HttpResponse, Error> {
     let discord_server_count = connected_discord_servers.load(std::sync::atomic::Ordering::SeqCst);
+
+    let mut redis_connection = redis_client
+        .get_connection()
+        .expect("Failed to get redis connection");
+
+    let today = chrono::Utc::now().date_naive().format("%Y-%m-%d");
+    let clan_chat_stats_key = format!("chat_stats:{}:clan_chat", today);
+
+    let total_chat_messages_for_today: RedisResult<i64> = redis_connection.get(clan_chat_stats_key);
+    if let Ok(total_chat_messages_for_today) = total_chat_messages_for_today {
+        return Ok(HttpResponse::Ok().json(BotInfo {
+            server_count: discord_server_count as i64,
+            connected_users: connected_websockets.lock().unwrap().clone() as i64,
+            total_chat_messages_for_today: Some(total_chat_messages_for_today),
+        }));
+    }
 
     Ok(HttpResponse::Ok().json(BotInfo {
         server_count: discord_server_count as i64,
         connected_users: connected_websockets.lock().unwrap().clone() as i64,
+        total_chat_messages_for_today: None,
     }))
 }
 

--- a/trackscape-discord-ui/src/services/TrackscapeApiTypes.ts
+++ b/trackscape-discord-ui/src/services/TrackscapeApiTypes.ts
@@ -1,6 +1,7 @@
 type BotInfo = {
   server_count: number;
   connected_users: number;
+  total_chat_messages_for_today: number | null
 }
 
 type Clan = {

--- a/trackscape-discord-ui/src/views/BotLandingPage.vue
+++ b/trackscape-discord-ui/src/views/BotLandingPage.vue
@@ -79,7 +79,7 @@ client.getBotInfo().then((info) => {
 
 
       <div class="mt-4 ">
-        <div class="stats">
+        <div class="stats stats-vertical md:stats-horizontal">
           <div class="stat">
             <div class="stat-title">
               Servers Joined
@@ -95,6 +95,14 @@ client.getBotInfo().then((info) => {
             </div>
             <div class="stat-value text-secondary">
               {{ botInfo?.connected_users.toLocaleString()}}
+            </div>
+          </div>
+          <div class="stat">
+            <div class="stat-title">
+              Messages sent today
+            </div>
+            <div class="stat-value text-accent">
+              {{ botInfo?.total_chat_messages_for_today?.toLocaleString()}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
TrackScape was already receiving clan chats in batches, but would send each one by it's own discord message. This change sends them as one Discord message if there's a batch of them received. 

Also added a new counter on the landing pages to see how many messages we are getting daily